### PR TITLE
Remove redundant find_package(OROCOS-RTT) call

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,21 +1,11 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rtt_boost_date_time_msgs)
 
-## Find Orocos RTT and plugins
-find_package(OROCOS-RTT 2.0.0 COMPONENTS rtt-scripting rtt-marshalling)
-if (NOT OROCOS-RTT_FOUND)
-  message(FATAL_ERROR "\n   RTT not found. Is the version correct? Use the CMAKE_PREFIX_PATH cmake or environment variable to point to the installation directory of RTT.")
-else()
-  include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
-  #add_definitions( -DRTT_COMPONENT )
-endif()
-
 ## find catkin and catkin dependencies
 find_package(catkin REQUIRED COMPONENTS rtt_roscomm boost_date_time_msgs)
 catkin_destinations()
 
 ## Build options
-
 if(NOT DEFINED CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Release")
   set(CMAKE_BUILD_TYPE MinSizeRel)
 endif()


### PR DESCRIPTION
RTT will be found implicitly by `find_package(catkin REQUIRED COMPONENTS rtt_roscomm)`.

See also related pull request https://github.com/orocos/rtt_kdl_msgs/pull/4 in https://github.com/orocos/rtt_kdl_msgs.