### PR TITLE
Include rtt-config.h header before ptime as it might define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG

### DIFF
--- a/src/ros_boost_date_time_msgs_transport.cpp
+++ b/src/ros_boost_date_time_msgs_transport.cpp
@@ -1,3 +1,6 @@
+// might define BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG
+#include <rtt/rtt-config.h>
+
 #include <boost_date_time_msgs/boost/Ptime.h>
 #include <boost_date_time_msgs/boost/TimeDuration.h>
 


### PR DESCRIPTION
See related commit https://github.com/orocos-toolchain/rtt/commit/9b0c9bcfd8d683dc6e66399a3b85b04706676a9b in RTT. I consider this patch as invalid because `BOOST_DATE_TIME_POSIX_TIME_STD_CONFIG` is actually a boost compile-time setting and defining it only before including the Boost headers might cause run-time errors when linking against code that was compiled without that option (e.g. Boost Thread, ROS, etc.).

But as long as it's there the transport library has to include the `rtt-config.h` header unconditionally.